### PR TITLE
Text Color Fix for State's districts list page

### DIFF
--- a/pages/[state]/index.js
+++ b/pages/[state]/index.js
@@ -16,14 +16,14 @@ export default function State({ state }) {
         el.district.toLowerCase().includes(searchStr.toLowerCase())
     );
     return (
-        <section className="md:pt-10">
+        <section className="md:pt-10 text-gray-800 ">
             <Head>
                 <title>{humanize(state)} | Coronasafe network</title>
             </Head>
             <Breadcumb list={[{ href: null, name: humanize(state) }]} />
-            <h1 className="mt-4 text-xl sm:text-2xl md:text-3xl text-gray-900 md:text-left">
+            <h1 className="mt-4 text-xl sm:text-2xl md:text-3xl md:text-left">
                 Search Result For{' '}
-                <span className="mt-4 font-bold text-3xl sm:text-4xl md:text-5xl text-gray-900 dark:text-gray-200 md:text-left">
+                <span className="mt-4 font-bold text-3xl sm:text-4xl md:text-5xl dark:text-gray-200 md:text-left">
                     "{humanize(state)}"
                 </span>
             </h1>

--- a/pages/[state]/index.js
+++ b/pages/[state]/index.js
@@ -23,7 +23,7 @@ export default function State({ state }) {
             <Breadcumb list={[{ href: null, name: humanize(state) }]} />
             <h1 className="mt-4 text-xl sm:text-2xl md:text-3xl md:text-left text-gray-900 dark:text-gray-800">
                 Search Result For{' '}
-                <span className="mt-4 font-bold text-3xl sm:text-4xl md:text-5xl dark:text-gray-200 md:text-left">
+                <span className="mt-4 font-bold text-3xl sm:text-4xl md:text-5xl text-gray-900 dark:text-gray-200 md:text-left">
                     "{humanize(state)}"
                 </span>
             </h1>

--- a/pages/[state]/index.js
+++ b/pages/[state]/index.js
@@ -16,12 +16,12 @@ export default function State({ state }) {
         el.district.toLowerCase().includes(searchStr.toLowerCase())
     );
     return (
-        <section className="md:pt-10 text-gray-800 ">
+        <section className="md:pt-10">
             <Head>
                 <title>{humanize(state)} | Coronasafe network</title>
             </Head>
             <Breadcumb list={[{ href: null, name: humanize(state) }]} />
-            <h1 className="mt-4 text-xl sm:text-2xl md:text-3xl md:text-left">
+            <h1 className="mt-4 text-xl sm:text-2xl md:text-3xl md:text-left text-gray-900 dark:text-gray-800">
                 Search Result For{' '}
                 <span className="mt-4 font-bold text-3xl sm:text-4xl md:text-5xl dark:text-gray-200 md:text-left">
                     "{humanize(state)}"
@@ -44,7 +44,7 @@ export default function State({ state }) {
                             className="w-full rounded overflow-hidden md:w-1/2 mb-6 hover:bg-gray-200 dark:hover:bg-gray-1200">
                             <div className="p-4">
                                 <Link href={`/${parametreize(state)}/${parametreize(f.district)}`}>
-                                    <span className="font-semibold text-2xl md:text-4xl py-6 hover:underline cursor-pointer">
+                                    <span className="font-semibold text-2xl md:text-4xl text-gray-900 dark:text-gray-800 py-6 hover:underline cursor-pointer">
                                         {humanize(f.district)}
                                     </span>
                                 </Link>


### PR DESCRIPTION
### **Changed the text's colour on the State's districts' list page for _optimal visibility_ in the dark mode.**

**Reason:**
When I first opened the website, it opened up in the dark mode and upon clicking on the states, the following texts: _(Districts' Name and title 'Search Result For')_ were not optimally visible on the dark mode. So as a concern for the people with weak eye sight, I have changed the colour of those texts for the optimal visibility and viewing experience on both dark and light mode.

Attaching images for the reference.

- **Updated Text Color(Dark)**<img width="1680" alt="Screenshot 2021-04-24 at 12 59 16 AM" src="https://user-images.githubusercontent.com/31177925/115921761-96176800-a499-11eb-965d-6ffbcf5e8378.png">
- **Previous Text Color(Dark)**<img width="1680" alt="Screenshot 2021-04-24 at 12 59 47 AM" src="https://user-images.githubusercontent.com/31177925/115921828-acbdbf00-a499-11eb-97c0-83570ecc773d.png">

- **Updated Text Color(Light)**<img width="1680" alt="Screenshot 2021-04-24 at 1 00 50 AM" src="https://user-images.githubusercontent.com/31177925/115921745-90218700-a499-11eb-8ea4-f81c43b6c989.png">
- **Previous Text Color(Light)**<img width="1680" alt="Screenshot 2021-04-24 at 1 00 59 AM" src="https://user-images.githubusercontent.com/31177925/115921851-b515fa00-a499-11eb-99d4-d2d614ef449c.png">