### PR TITLE
🚀 Fix Re-Rendering of Components when using Locale Hooks

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,17 +1,16 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faDatabase,
     faHandsHelping,
     faHeart,
     faBookOpen,
-    faInfo
 } from '@fortawesome/free-solid-svg-icons';
 import useLocale from '@hooks/use-locale';
 import { useLocaleContext } from '@hooks/use-locale-context';
 
 const Footer = () => {
-    const { locale, setLocale } = useLocaleContext();
+    const { locale } = useLocaleContext();
     const t = useLocale(locale, 'home');
     const buttonArr = [
         {

--- a/components/LanguageSelector.jsx
+++ b/components/LanguageSelector.jsx
@@ -1,14 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocaleContext } from '@hooks/use-locale-context';
 import langArr from '@locales/index';
 
 const LanguageSelector = () => {
+
     const { locale, setLocale } = useLocaleContext();
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const storedLanguage = localStorage.getItem("language")
+            if (storedLanguage) {
+                setLocale(storedLanguage.toUpperCase());
+            } else {
+                localStorage.setItem('language', 'EN');
+            }
+        }
+    }, []);
+
+    const handleChangeLocale = ({ target: { value } }) => {
+        setLocale(value);
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('language', value);
+        }
+    }
+
     return (
         <select
             className="cursor-pointer fixed top-3 left-3 font-semibold text-sm rounded shadow h-8 dark:bg-gray-1000 px-2 dark:text-white appearance-none "
             value={locale}
-            onChange={(e) => setLocale(e.target.value)}>
+            onChange={handleChangeLocale}>
             {langArr.map((el) => (
                 <option key={el.code} value={el.code}>
                     {el.name}

--- a/hooks/use-locale-context.js
+++ b/hooks/use-locale-context.js
@@ -1,20 +1,10 @@
-import { createContext } from 'react';
-import { useContext } from 'react';
+import { createContext, useContext } from 'react';
 
-export const LocaleContext = createContext(null);
+export const LocaleContext = createContext({
+    locale: "EN",
+    setLocale: (_) => {}
+});
 
-export function useLocaleContext() {
-    const { locale, setBaseLocal } = useContext(LocaleContext);
-    if (typeof window !== 'undefined') {
-        if (localStorage.language === undefined) {
-            localStorage.setItem('language', 'EN');
-        } else {
-            setBaseLocal(localStorage.getItem('language'));
-        }
-    }
-    const setLocale = (loc) => {
-        setBaseLocal(loc);
-        localStorage.setItem('language', loc.toUpperCase());
-    };
-    return { locale, setLocale };
+export const useLocaleContext = () => {
+    return useContext(LocaleContext);
 }

--- a/layouts/MainLayout.jsx
+++ b/layouts/MainLayout.jsx
@@ -5,8 +5,10 @@ import { LocaleContext } from '@hooks/use-locale-context';
 import LanguageSelector from '@components/LanguageSelector';
 
 const MainLayout = ({ children }) => {
-    const [locale, setBaseLocal] = useState('EN');
-    const value = { locale, setBaseLocal };
+
+    const [locale, setLocale] = useState("EN");
+    const localeValue = { locale, setLocale };
+
     useEffect(() => {
         if (typeof window !== 'undefined') {
             if (
@@ -22,7 +24,7 @@ const MainLayout = ({ children }) => {
     }, []);
 
     return (
-        <LocaleContext.Provider value={value}>
+        <LocaleContext.Provider value={localeValue}>
             <div className="flex flex-col items-stretch min-h-screen bg-gray-100 dark:bg-gray-1100">
                 <div className="relative flex-shrink-0">
                     <ThemeButton />


### PR DESCRIPTION
## Proposed Changes 🎉

- Removed State Setting Logic from the Hook 🧹
- Move Locale Persistence logic to LanguageSelector 🚜

#### 🎯 Note 
> `useLocaleContext` is now just `useContext(LocaleContext)`. This is kept to avoid changing of bulk files 📍

Resolves #143 🔥