### PR TITLE
Padding Between Logo and borders

### DIFF
--- a/components/PartnerCard.jsx
+++ b/components/PartnerCard.jsx
@@ -4,16 +4,11 @@ const PartnerCard = ({ name, logoURL, url }) => {
     return (
         <div className="inline-block overflow:hidden">
             <a href={url} target="_blank">
-                <div
-                    className=" max-w-md shadow my-3 mx-2 border rounded border-gray-300 dark:border-gray-900 cursor-pointer px-2 py-2">
-                    <div className="bg-white w-36 h-36">
-                        <img
-                            src={logoURL}
-                            alt={`${name} Logo`}
-                            className="object-contain h-36 py-4"
-                        />
+                <div className="w-44 max-w-md shadow my-3 mx-4 border rounded border-gray-300 dark:border-gray-900 cursor-pointer">
+                    <div className="bg-white w-full h-40 p-2">
+                        <img src={logoURL} alt={`${name} Logo`} className="h-36 object-contain" />
                     </div>
-                    <div className="text-center text-md py-2 border-t-2 w-full border-gray-300 dark:border-gray-900">
+                    <div className="text-center text-md px-2 py-2 border-t-2 w-full border-gray-300 dark:border-gray-900">
                         {name}
                     </div>
                 </div>


### PR DESCRIPTION
### Added gap between logo and boundary. Also the logos dimensions were breaking
Desktop View
![image](https://user-images.githubusercontent.com/42883572/116697090-622fcb80-a9e0-11eb-9d8b-dcdda30f10b5.png)
IPad View
![image](https://user-images.githubusercontent.com/42883572/116697166-7c69a980-a9e0-11eb-834b-8c62fa9c29e1.png)
Mobile View
![image](https://user-images.githubusercontent.com/42883572/116697248-93100080-a9e0-11eb-8271-545c5007c9ac.png)
