### PR TITLE
LIFE:265: Hiding results sections if results are not available

### DIFF
--- a/components/DetailedHome.jsx
+++ b/components/DetailedHome.jsx
@@ -171,7 +171,7 @@ export default function DetailedHome({ state, district, type }) {
                 </section>
                 {resourceChoosen ? (
                     <>
-                        <HomeTabs tabVal={tabVal} onChange={changeTabs} />
+                        <HomeTabs tabVal={tabVal} onChange={changeTabs} resources={resources[resourceChoosen]} />
                         <div style={{ minHeight: '315px' }}>
                             {tabVal === 'result' && (
                                 <SearchResult

--- a/components/HomeTabs.jsx
+++ b/components/HomeTabs.jsx
@@ -4,20 +4,24 @@ import { faHeartbeat } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTwitter, faGoogle } from '@fortawesome/free-brands-svg-icons';
 
-const HomeTabs = ({ tabVal, onChange }) => {
+const HomeTabs = ({ tabVal, onChange, resources }) => {
     return (
         <div className="dark:text-gray-200 mx-auto max-w-xs text-base flex font-bold justify-around my-6 cursor-pointer">
-            <div
-                className={`w-3/6 flex justify-center items-center pb-2  ${(tabVal === 'result' ) ? `border-b-2 border-gray-900 dark:border-gray-300` : ``
-                    }`}
-                onClick={() => onChange('result')}>
-                <FontAwesomeIcon
-                    className="text-primary-500 w-5 mr-2"
-                    title="View Search Results"
-                    icon={faHeartbeat}
-                />
-                Results
-            </div>
+            { resources.length > 0 ? 
+                (
+                    <div
+                        className={`w-3/6 flex justify-center items-center pb-2  ${(tabVal === 'result' ) ? `border-b-2 border-gray-900 dark:border-gray-300` : ``
+                            }`}
+                        onClick={() => onChange('result')}>
+                        <FontAwesomeIcon
+                            className="text-primary-500 w-5 mr-2"
+                            title="View Search Results"
+                            icon={faHeartbeat}
+                        />
+                        Results
+                    </div>
+                ) : null
+            }
             <div
                 className={`w-3/6 flex justify-center items-center pb-2  ${(tabVal === 'twitter' || tabVal === "twitter_on_no_data") ? `border-b-2 border-gray-900 dark:border-gray-300` : ``
                     }`}


### PR DESCRIPTION
Fixes [265](https://github.com/coronasafe/life/issues/265)

Hiding results sections if results are not available in selected state/district. 


<img width="1346" alt="Screenshot 2021-05-05 at 5 36 24 PM" src="https://user-images.githubusercontent.com/7491303/117138291-7270ed80-adc8-11eb-9d99-da018e576a60.png">
